### PR TITLE
修复Netlify的跨域问题

### DIFF
--- a/.github/workflows/friend_circle_lite.yml
+++ b/.github/workflows/friend_circle_lite.yml
@@ -71,25 +71,25 @@ jobs:
 
     - name: Commit changes
   run: |
-    # 先获取当前的 netlify.toml（如果存在）
-    git fetch origin page || true
-    if git show-ref --verify --quiet refs/heads/page; then
-      git show origin/page:netlify.toml > /tmp/netlify.toml 2>/dev/null || echo "没有现有的 netlify.toml"
-    fi
-    
-    # 正常生成内容
     mkdir pages
-    cp -r main ./static/* ./temp/cache.json all.json errors.json pages/ 2>/dev/null || true
+    cp -r main ./static/* ./temp/* all.json errors.json pages/ 2>/dev/null || true
     
-    # 恢复 netlify.toml
+    # 直接在这里创建 netlify.toml
     cd pages
-    if [ -f /tmp/netlify.toml ]; then
-      cp /tmp/netlify.toml ./netlify.toml
-    fi
+    cat > netlify.toml << 'EOF'
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, POST, OPTIONS"
+    Access-Control-Allow-Headers = "Content-Type"
+EOF
     
     git init
     git add .
-    git commit -m "Update"
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git commit -m "Update page branch with netlify.toml"
     git push --force https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:page
 
     - name: Delete Workflow Runs

--- a/.github/workflows/friend_circle_lite.yml
+++ b/.github/workflows/friend_circle_lite.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         mkdir pages
         cp -r main ./static/edgeone.json ./static/index.html ./static/readme.md ./static/favicon.ico ./static/bg-light.webp ./temp/cache.json ./static/bg-dark.webp all.json errors.json pages/
-        cp -r main ./static/* ./temp/* netlify.toml all.json errors.json pages/
+        cp -r main ./static/* ./temp/* all.json errors.json pages/
         cd pages
         git init
         git add .

--- a/.github/workflows/friend_circle_lite.yml
+++ b/.github/workflows/friend_circle_lite.yml
@@ -72,8 +72,7 @@ jobs:
     - name: Commit changes
       run: |
         mkdir pages
-        cp -r main ./static/edgeone.json ./static/index.html ./static/readme.md ./static/favicon.ico ./static/bg-light.webp ./temp/cache.json ./static/bg-dark.webp all.json errors.json pages/
-        cp -r main ./static/* ./temp/* all.json errors.json pages/
+        cp -r main ./static/edgeone.json ./static/index.html ./static/readme.md ./static/favicon.ico ./static/bg-light.webp ./temp/cache.json ./static/bg-dark.webp all.json errors.json ./static/netlify.toml pages/
         cd pages
         git init
         git add .

--- a/.github/workflows/friend_circle_lite.yml
+++ b/.github/workflows/friend_circle_lite.yml
@@ -73,6 +73,7 @@ jobs:
       run: |
         mkdir pages
         cp -r main ./static/edgeone.json ./static/index.html ./static/readme.md ./static/favicon.ico ./static/bg-light.webp ./temp/cache.json ./static/bg-dark.webp all.json errors.json pages/
+        cp -r main ./static/* ./temp/* netlify.toml all.json errors.json pages/
         cd pages
         git init
         git add .

--- a/.github/workflows/friend_circle_lite.yml
+++ b/.github/workflows/friend_circle_lite.yml
@@ -70,14 +70,27 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
     - name: Commit changes
-      run: |
-        mkdir pages
-        cp -r main ./static/edgeone.json ./static/index.html ./static/readme.md ./static/favicon.ico ./static/bg-light.webp ./temp/cache.json ./static/bg-dark.webp all.json errors.json pages/
-        cd pages
-        git init
-        git add .
-        git commit -m "⏱️ $(date +"%Y年%m月%d日-%H时%M分") GitHub Actions定时更新"
-        git push --force https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:page
+  run: |
+    # 先获取当前的 netlify.toml（如果存在）
+    git fetch origin page || true
+    if git show-ref --verify --quiet refs/heads/page; then
+      git show origin/page:netlify.toml > /tmp/netlify.toml 2>/dev/null || echo "没有现有的 netlify.toml"
+    fi
+    
+    # 正常生成内容
+    mkdir pages
+    cp -r main ./static/* ./temp/cache.json all.json errors.json pages/ 2>/dev/null || true
+    
+    # 恢复 netlify.toml
+    cd pages
+    if [ -f /tmp/netlify.toml ]; then
+      cp /tmp/netlify.toml ./netlify.toml
+    fi
+    
+    git init
+    git add .
+    git commit -m "Update"
+    git push --force https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:page
 
     - name: Delete Workflow Runs
       uses: Mattraks/delete-workflow-runs@v2

--- a/.github/workflows/friend_circle_lite.yml
+++ b/.github/workflows/friend_circle_lite.yml
@@ -70,27 +70,14 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
     - name: Commit changes
-  run: |
-    mkdir pages
-    cp -r main ./static/* ./temp/* all.json errors.json pages/ 2>/dev/null || true
-    
-    # 直接在这里创建 netlify.toml
-    cd pages
-    cat > netlify.toml << 'EOF'
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Access-Control-Allow-Origin = "*"
-    Access-Control-Allow-Methods = "GET, POST, OPTIONS"
-    Access-Control-Allow-Headers = "Content-Type"
-EOF
-    
-    git init
-    git add .
-    git config user.name "github-actions[bot]"
-    git config user.email "github-actions[bot]@users.noreply.github.com"
-    git commit -m "Update page branch with netlify.toml"
-    git push --force https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:page
+      run: |
+        mkdir pages
+        cp -r main ./static/edgeone.json ./static/index.html ./static/readme.md ./static/favicon.ico ./static/bg-light.webp ./temp/cache.json ./static/bg-dark.webp all.json errors.json pages/
+        cd pages
+        git init
+        git add .
+        git commit -m "⏱️ $(date +"%Y年%m月%d日-%H时%M分") GitHub Actions定时更新"
+        git push --force https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:page
 
     - name: Delete Workflow Runs
       uses: Mattraks/delete-workflow-runs@v2

--- a/conf.yaml
+++ b/conf.yaml
@@ -8,11 +8,11 @@
 #     marge_json_path:  请填写网络地址的json文件，用于合并，不带空格！！！
 spider_settings:
   enable: true
-  json_url: "https://blog.liushen.fun/friend.json"
+  json_url: "https://wanblog.qzz.io/friend.json"
   article_count: 5
   merge_result:
     enable: false
-    merge_json_url: "https://fc.liushen.fun"
+    merge_json_url: "https://fc.wanblog.qzz.io"
 
 # 邮箱推送功能配置，暂未实现，等待后续开发
 # 解释：每天为指定邮箱推送所有友链文章的更新，仅能指定一个

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,0 @@
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Access-Control-Allow-Origin = "*"
-    Access-Control-Allow-Methods = "GET, OPTIONS"
-    Access-Control-Allow-Headers = "*"

--- a/static/netlify.toml
+++ b/static/netlify.toml
@@ -1,0 +1,6 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "*"


### PR DESCRIPTION
在工作流中添加Netlify.toml，方便在page页面复制，解决了用Netlify部署的跨域问题

## Summary by Sourcery

Add Netlify-specific configuration and update URLs to fix cross-origin issues for the deployed friend circle pages.

Bug Fixes:
- Configure Netlify response headers to allow cross-origin access to the generated pages.

Enhancements:
- Update external JSON and merge endpoint URLs used by the spider configuration to point to the new domains.

CI:
- Include the Netlify configuration file in the GitHub Actions workflow output so it is deployed with the generated pages.